### PR TITLE
WIP support for enums with fields

### DIFF
--- a/enum-iterator-derive/Cargo.toml
+++ b/enum-iterator-derive/Cargo.toml
@@ -17,3 +17,7 @@ proc-macro = true
 proc-macro2 = "1.0.4"
 quote = "1.0.2"
 syn = "1.0.5"
+
+[dependencies.itertools]
+version = "0.9.0"
+default-features = false

--- a/enum-iterator-derive/src/lib.rs
+++ b/enum-iterator-derive/src/lib.rs
@@ -9,10 +9,12 @@
 
 extern crate proc_macro;
 
+use itertools::izip;
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens};
 use std::fmt::{Display, self};
-use syn::{Ident, DeriveInput};
+use std::iter;
+use syn::{Ident, DeriveInput, Token, punctuated::Punctuated};
 
 /// Derives `IntoEnumIterator` for field-less enums.
 #[proc_macro_derive(IntoEnumIterator)]
@@ -33,51 +35,125 @@ fn derive(input: proc_macro::TokenStream) -> Result<TokenStream, syn::Error> {
         syn::Data::Enum(e) => &e.variants,
         _ => return Err(Error::ExpectedEnum.with_tokens(&ast)),
     };
-    let arms = variants.iter().enumerate()
-        .map(|(idx, v)| {
+    let iter_variants = variants.iter()
+        .map(|v| {
             let id = &v.ident;
             match v.fields {
-                syn::Fields::Unit => Ok(quote! { #idx => #ty::#id, }),
-                _ => Err(Error::ExpectedUnitVariant.with_tokens(v)),
+                syn::Fields::Unit => quote!(#id),
+                syn::Fields::Unnamed(syn::FieldsUnnamed { ref unnamed, .. }) => {
+                    let field_iters = unnamed.iter().map(|field| {
+                        let field_ty = &field.ty;
+                        quote!((<#field_ty as ::enum_iterator::IntoEnumIterator>::Iterator, Option<<<#field_ty as ::enum_iterator::IntoEnumIterator>::Iterator as ::core::iter::Iterator>::Item>))
+                    });
+                    quote!(#id(#(#field_iters,)*))
+                }
+                syn::Fields::Named(syn::FieldsNamed { ref named, .. }) => {
+                    let field_iters = named.iter().map(|field| {
+                        let field_name = &field.ident.as_ref().expect("named field should have a name");
+                        let field_ty = &field.ty;
+                        quote!(#field_name: (<#field_ty as ::enum_iterator::IntoEnumIterator>::Iterator, Option<<<#field_ty as ::enum_iterator::IntoEnumIterator>::Iterator as ::core::iter::Iterator>::Item>))
+                    });
+                    quote!(#id { #(#field_iters,)* })
+                }
             }
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-    let nb_variants = arms.len();
+        });
+    let mut constructors = variants.iter()
+        .map(|v| {
+            let id = &v.ident;
+            match v.fields {
+                syn::Fields::Unit => quote!(#iter_ty::#id),
+                syn::Fields::Unnamed(syn::FieldsUnnamed { ref unnamed, .. }) => {
+                    let field_iters = unnamed.iter().map(|field| {
+                        let field_ty = &field.ty;
+                        quote!((<#field_ty as ::enum_iterator::IntoEnumIterator>::Iterator::__EnumIterStart, ::core::option::Option::None))
+                    });
+                    quote!(#iter_ty::#id(#(#field_iters,)*))
+                }
+                syn::Fields::Named(syn::FieldsNamed { ref named, .. }) => {
+                    let field_iters = named.iter().map(|field| {
+                        let field_name = &field.ident.as_ref().expect("named field should have a name");
+                        let field_ty = &field.ty;
+                        quote!(#field_name: (<#field_ty as ::enum_iterator::IntoEnumIterator>::Iterator::__EnumIterStart, ::core::option::Option::None))
+                    });
+                    quote!(#iter_ty::#id { #(#field_iters,)* })
+                }
+            }
+        });
+    let first_constructor = constructors.next().unwrap_or(quote!(#iter_ty::__EnumIterDone));
+    let arms = variants.iter().zip(constructors.chain(iter::once(quote!(#iter_ty::__EnumIterDone))))
+        .map(|(v, next_constructor)| {
+            let id = &v.ident;
+            match v.fields {
+                syn::Fields::Unit => quote! {
+                    #iter_ty::#id => {
+                        *self = #next_constructor;
+                        break ::core::option::Option::Some(#ty::#id)
+                    }
+                },
+                syn::Fields::Unnamed(syn::FieldsUnnamed { ref unnamed, .. }) => {
+                    let (field_iters, field_caches, elt_defs, elts) = variant_iter(next_constructor, unnamed);
+                    quote! {
+                        #iter_ty::#id(#((#field_iters, #field_caches),)*) => {
+                            #(#elt_defs)*
+                            break ::core::option::Option::Some(#ty::#id(#(#elts,)*))
+                        }
+                    }
+                }
+                syn::Fields::Named(syn::FieldsNamed { ref named, .. }) => {
+                    let field_names = named.iter().map(|field| field.ident.as_ref().expect("unnamed field in struct variant")).collect::<Vec<_>>();
+                    let (field_iters, field_caches, elt_defs, elts) = variant_iter(next_constructor, named);
+                    quote! {
+                        #iter_ty::#id { #(#field_names: (#field_iters, #field_caches),)* } => {
+                            #(#elt_defs)*
+                            break ::core::option::Option::Some(#ty::#id { #(#field_names: #elts,)* })
+                        }
+                    }
+                }
+            }
+        });
     let tokens = quote! {
         #[doc = #ty_doc]
         #[derive(Clone, Copy, Debug)]
-        #vis struct #iter_ty {
-            idx: usize,
+        #vis enum #iter_ty {
+            __EnumIterStart,
+            #(#iter_variants,)*
+            __EnumIterDone,
         }
 
         impl ::core::iter::Iterator for #iter_ty {
             type Item = #ty;
 
             fn next(&mut self) -> ::core::option::Option<Self::Item> {
-                let id = match self.idx {
-                    #(#arms)*
-                    _ => return ::core::option::Option::None,
-                };
-                self.idx += 1;
-                ::core::option::Option::Some(id)
+                loop {
+                    match self {
+                        Self::__EnumIterStart => *self = #first_constructor,
+                        #(#arms)*
+                        Self::__EnumIterDone => break ::core::option::Option::None,
+                    }
+                }
             }
 
+            /*
             fn size_hint(&self) -> (usize, ::core::option::Option<usize>) {
-                let n = #nb_variants - self.idx;
-                (n, ::core::option::Option::Some(n))
+                //TODO use previous impl if fieldless enum
+                (0, ::core::option::Option::Some(#nb_elts))
             }
+            */
         }
 
-        impl ::core::iter::ExactSizeIterator for #iter_ty {}
+        //TODO “uncomment” if fieldless enum
+        //impl ::core::iter::ExactSizeIterator for #iter_ty {}
         impl ::core::iter::FusedIterator for #iter_ty {}
 
         impl ::enum_iterator::IntoEnumIterator for #ty {
             type Iterator = #iter_ty;
 
-            const VARIANT_COUNT: usize = #nb_variants;
+            //TODO
+            //const VARIANT_COUNT: usize = #nb_variants;
+            //const ELEMENT_COUNT: usize = #nb_elts;
 
             fn into_enum_iter() -> Self::Iterator {
-                #iter_ty { idx: 0 }
+                #iter_ty::__EnumIterStart
             }
         }
     };
@@ -89,10 +165,53 @@ fn derive(input: proc_macro::TokenStream) -> Result<TokenStream, syn::Error> {
     Ok(tokens)
 }
 
+fn variant_iter(next_constructor: TokenStream, fields: &Punctuated<syn::Field, Token![,]>) -> (Vec<Ident>, Vec<Ident>, Vec<TokenStream>, Vec<Ident>) {
+    let field_types = fields.iter().map(|field| &field.ty);
+    let field_iters = (0..fields.len()).map(|idx| Ident::new(&format!("__iter{}", idx), Span::call_site())).collect::<Vec<_>>();
+    let field_caches = (0..fields.len()).map(|idx| Ident::new(&format!("__cache{}", idx), Span::call_site())).collect::<Vec<_>>();
+    let elts = (0..fields.len()).map(|idx| Ident::new(&format!("__elt{}", idx), Span::call_site())).collect::<Vec<_>>();
+    let elt_defs = izip!(field_types, &field_iters, &field_caches, &elts).enumerate().map(|(idx, (field_ty, iter, cache, elt))| {
+        let cache_lookup = if idx == fields.len() - 1 { quote!(#cache.take()) } else { quote!(#cache.as_ref()) };
+        let cache_read = if idx == fields.len() - 1 { quote!(#elt) } else { quote!(#elt.clone()) };
+        let cache_write = if idx == fields.len() - 1 { quote!(#elt) } else { quote!({
+            #cache = ::core::option::Option::Some(#elt.clone());
+            #elt
+        }) };
+        let handle_end = if idx == 0 {
+            quote!({
+                *self = #next_constructor;
+                continue
+            })
+        } else {
+            let prev_cache = &field_caches[idx - 1];
+            let cache_writes = (idx + 1..fields.len()).map(|idx| {
+                let cache = &field_caches[idx];
+                let elt = &elts[idx];
+                quote!(*#cache = ::core::option::Option::Some(#elt);)
+            });
+            quote!({
+                *#prev_cache = ::core::option::Option::None;
+                *#iter = <#field_ty as ::enum_iterator::IntoEnumIterator>::Iterator::__EnumIterStart;
+                #(#cache_writes)*
+                continue
+            })
+        };
+        quote! {
+            let #elt = match #cache_lookup {
+                ::core::option::Option::Some(#elt) => #cache_read,
+                ::core::option::Option::None => match #iter.next() {
+                    ::core::option::Option::Some(#elt) => #cache_write,
+                    ::core::option::Option::None => #handle_end,
+                }
+            };
+        }
+    }).collect();
+    (field_iters, field_caches, elt_defs, elts)
+}
+
 #[derive(Debug)]
 enum Error {
     ExpectedEnum,
-    ExpectedUnitVariant,
     GenericsUnsupported,
 }
 
@@ -107,9 +226,6 @@ impl Display for Error {
         match self {
             Error::ExpectedEnum =>
                 f.write_str("IntoEnumIterator can only be derived for enum types"),
-            Error::ExpectedUnitVariant =>
-                f.write_str("IntoEnumIterator can only be derived for enum types with unit \
-                    variants only"),
             Error::GenericsUnsupported =>
                 f.write_str("IntoEnumIterator cannot be derived for generic types"),
         }

--- a/enum-iterator/src/lib.rs
+++ b/enum-iterator/src/lib.rs
@@ -36,10 +36,12 @@ use core::iter;
 /// ```
 pub trait IntoEnumIterator: Sized {
     /// Type of the iterator over the variants.
-    type Iterator: Iterator<Item = Self> + iter::ExactSizeIterator + iter::FusedIterator + Copy;
+    type Iterator: Iterator<Item = Self> /*+ iter::ExactSizeIterator*/ + iter::FusedIterator + Copy; //TODO
 
-    /// Number of variants.
-    const VARIANT_COUNT: usize;
+    ///// Number of variants.
+    //const VARIANT_COUNT: usize; //TODO
+    ///// Number of elements.
+    //const ELEMENT_COUNT: usize; //TODO
 
     /// Returns an iterator over the variants.
     ///


### PR DESCRIPTION
This adds support for deriving `IntoEnumIterator` for enums with non-unit variants, as long as each field also implements `IntoEnumIterator`.

For variants with multiple fields, the implementation iterates over the [Cartesian product](https://en.wikipedia.org/wiki/Cartesian_product) of the fields' values. Example:

```rust
#[derive(IntoEnumIterator, PartialEq, Eq)] enum Left { A, B }
#[derive(IntoEnumIterator, PartialEq, Eq)] enum Right { X, Y, Z }

#[derive(IntoEnumIterator, PartialEq, Eq)]
enum Example {
    First,
    Second(Left, Right),
}

assert_eq!(Example::into_enum_iter().collect(), vec![
    Example::First,
    Example::Second(Left::A, Right::X),
    Example::Second(Left::A, Right::Y),
    Example::Second(Left::A, Right::Z),
    Example::Second(Left::B, Right::X),
    Example::Second(Left::B, Right::Y),
    Example::Second(Left::B, Right::Z),
]);
```

Submitting as a draft because `nb_variants` and everything dependent on that (e.g. the `ExactSizeIterator` impl) still needs to be reimplemented.