### PR TITLE
Make next_cycle and previous_cycle not return Options

### DIFF
--- a/enum-iterator/Cargo.toml
+++ b/enum-iterator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enum-iterator"
-version = "1.5.0"
+version = "2.0.0"
 authors = ["Stephane Raux <stephaneyfx@gmail.com>"]
 edition = "2021"
 description = "Tools to iterate over all values of a type (e.g. all variants of an enumeration)"

--- a/enum-iterator/src/lib.rs
+++ b/enum-iterator/src/lib.rs
@@ -148,10 +148,10 @@ pub fn next<T: Sequence>(x: &T) -> Option<T> {
 /// #[derive(Debug, PartialEq, Sequence)]
 /// enum Day { Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday }
 ///
-/// assert_eq!(next_cycle(&Day::Sunday), Some(Day::Monday));
+/// assert_eq!(next_cycle(&Day::Sunday), Day::Monday);
 /// ```
-pub fn next_cycle<T: Sequence>(x: &T) -> Option<T> {
-    next(x).or_else(first)
+pub fn next_cycle<T: Sequence>(x: &T) -> T {
+    next(x).or_else(first).expect("Sequence::first returned None for inhabited type")
 }
 
 /// Returns the previous value of type `T` or `None` if this was the beginning.
@@ -180,10 +180,10 @@ pub fn previous<T: Sequence>(x: &T) -> Option<T> {
 /// #[derive(Debug, PartialEq, Sequence)]
 /// enum Day { Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday }
 ///
-/// assert_eq!(previous_cycle(&Day::Monday), Some(Day::Sunday));
+/// assert_eq!(previous_cycle(&Day::Monday), Day::Sunday);
 /// ```
-pub fn previous_cycle<T: Sequence>(x: &T) -> Option<T> {
-    previous(x).or_else(last)
+pub fn previous_cycle<T: Sequence>(x: &T) -> T {
+    previous(x).or_else(last).expect("Sequence::last returned None for inhabited type")
 }
 
 /// Returns the first value of type `T`.
@@ -284,6 +284,9 @@ impl<T: Sequence> FusedIterator for ReverseAll<T> {}
 /// - `T::last().and_then(|x| x.next()).is_none()`
 /// - `T::first().is_none()` ⇔ `T::last().is_none()`
 /// - `std::iter::successors(T::first(), T::next)` must eventually yield `T::last()`.
+/// - If `T` is inhabited, `T::first().is_some()`.
+///
+/// If a manual implementation of `Sequence` violates any of these laws, the functions at the crate root may misbehave, including panicking.
 ///
 /// # Examples
 /// ## C-like enumeration


### PR DESCRIPTION
This PR changes the return type of the top-level functions `next_cycle` and `previous_cycle` from `Option<T>` to `T`, allowing users of this library to skip the `Option` handling. This is possible because these functions take a parameter `x` of type `&T`, which means that the type `T` has at least one value (`*x`), so `first` and `last` should always return `Some`. To formalize this, I have added an additional “law” to the trait documentation on `Sequence` requiring that inhabited types must have a `first` value, which is in line with the idea that a `Sequence` implementation should enumerate _all_ values of the type.

This is a breaking change, so the version is bumped to 2.0.0.