### PR TITLE
Iterate over default's field variants in enums

### DIFF
--- a/enum-iterator-derive/Cargo.toml
+++ b/enum-iterator-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enum-iterator-derive"
-version = "1.5.0"
+version = "1.6.0"
 authors = ["Stephane Raux <stephaneyfx@gmail.com>"]
 edition = "2021"
 description = "Procedural macro to derive Sequence"

--- a/enum-iterator/Cargo.toml
+++ b/enum-iterator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enum-iterator"
-version = "2.3.0"
+version = "2.4.0"
 authors = ["Stephane Raux <stephaneyfx@gmail.com>"]
 edition = "2021"
 description = "Tools to iterate over all values of a type (e.g. all variants of an enumeration)"

--- a/enum-iterator/README.md
+++ b/enum-iterator/README.md
@@ -53,6 +53,24 @@ assert_eq!(first::<Foo>(), Some(Foo { a: false, b: 0 }));
 assert_eq!(last::<Foo>(), Some(Foo { a: true, b: 255 }));
 ```
 
+```rust
+use enum_iterator::{Sequence};
+use core::default;
+
+#[derive(Debug, PartialEq, Sequence)]
+#[enum_iterator(use_default)]
+enum Id {
+    Name { first: String, last: String },
+    Empty,
+    Alias(String),
+}
+
+let number = Id::Empty;
+
+assert_eq!(number.next(), Some(Id::Alias(default::Default())));
+assert_eq!(number.previous(), Some(Id::Name {first: default::Default(), last: default::Default()}));
+```
+
 # Rust version
 This crate tracks stable Rust. Minor releases may require a newer Rust version. Patch releases
 must not require a newer Rust version.

--- a/enum-iterator/src/lib.rs
+++ b/enum-iterator/src/lib.rs
@@ -64,6 +64,17 @@
 //! #[enum_iterator(crate = enum_iterator)]
 //! struct Foo;
 //! ```
+//! 
+//! # Iterate over enum's default variant
+//! 
+//! For enums with only unit variants or variants with fields implementing [`core::default::Default`],
+//! is is possible to iterate over them using the `use_default` parameter.
+//! 
+//! ```
+//! #[derive(enum_iterator::Sequence)]
+//! #[enum_iterator(use_default)]
+//! enum Foo;
+//! ```
 //!
 //! # Rust version
 //! This crate tracks stable Rust. Minor releases may require a newer Rust version. Patch releases

--- a/enum-iterator/src/lib.rs
+++ b/enum-iterator/src/lib.rs
@@ -73,7 +73,7 @@
 //! ```
 //! #[derive(enum_iterator::Sequence)]
 //! #[enum_iterator(use_default)]
-//! enum Foo;
+//! enum Foo {};
 //! ```
 //!
 //! # Rust version

--- a/enum-iterator/tests/derive.rs
+++ b/enum-iterator/tests/derive.rs
@@ -181,3 +181,73 @@ fn all_values_of_unit_are_yielded() {
 fn all_values_of_unit_are_yielded_in_reverse() {
     assert_eq!(reverse_all::<Unit>().collect::<Vec<_>>(), vec![Unit]);
 }
+
+#[derive(Debug, PartialEq, Sequence)]
+#[enum_iterator(use_default)]
+enum Id {
+    Number(u32),
+    Alias(String),
+    Name { first: String, last: String },
+    Empty,
+}
+
+#[test]
+fn all_values_of_defaults_are_yielded() {
+    assert_eq!(cardinality::<Id>(), 4);
+    assert_eq!(
+        all::<Id>().collect::<Vec<_>>(),
+        vec![
+            Id::Number(Default::default()),
+            Id::Alias(Default::default()),
+            Id::Name {
+                first: Default::default(),
+                last: Default::default()
+            },
+            Id::Empty,
+        ]
+    );
+}
+
+#[test]
+fn iterate_over_defaults_reverse() {
+    let id = Id::Empty;
+
+    let name = id.previous().unwrap();
+    assert_eq!(
+        name,
+        Id::Name {
+            first: Default::default(),
+            last: Default::default(),
+        }
+    );
+
+    let alias = name.previous().unwrap();
+    assert_eq!(alias, Id::Alias(Default::default()));
+
+    let number = alias.previous().unwrap();
+    assert_eq!(number, Id::Number(Default::default()));
+
+    assert!(number.previous().is_none());
+}
+
+#[test]
+fn iterate_over_defaults() {
+    let id = Id::Number(5);
+
+    let alias = id.next().unwrap();
+    assert_eq!(alias, Id::Alias(Default::default()));
+
+    let name = alias.next().unwrap();
+    assert_eq!(
+        name,
+        Id::Name {
+            first: Default::default(),
+            last: Default::default(),
+        }
+    );
+
+    let empty = name.next().unwrap();
+    assert_eq!(empty, Id::Empty);
+
+    assert!(empty.next().is_none());
+}


### PR DESCRIPTION
Hi

I needed to iterate over en enum's default variant, so I added a option to enum-iterator.

If you prefer other terms or structure I would be glad to adapt.

All tests are good.